### PR TITLE
Added complete LLVM build process for future reference.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,6 @@ RUN cd /home && \
     git clone https://github.com/Johnn333/codal-microbit-nrf5sdk-clang codal-microbit-nrf5sdk && \
     cd codal-microbit-nrf5sdk && \
     git switch clang-revised && \
-    echo 2 && \ 
     
     cd /home/microbit-v2-samples-llvm/libraries/codal-microbit-v2 && \
     

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,15 +57,12 @@ RUN cd /home && \
     mkdir libraries && cd libraries && \
     git clone https://github.com/lancaster-university/codal-microbit-v2 codal-microbit-v2 && \
     git clone https://github.com/lancaster-university/codal-core codal-core  && \
+    git clone https://github.com/microbit-foundation/codal-microbit-nrf5sdk codal-microbit-nrf5sdk && \
     git clone https://github.com/lancaster-university/codal-nrf52 codal-nrf52 && \
     cd codal-nrf52 && \
     git submodule init && \ 
     git submodule update && \
     cd .. && \
-    # Waiting on SDK changes to be merged
-    git clone https://github.com/Johnn333/codal-microbit-nrf5sdk-clang codal-microbit-nrf5sdk && \
-    cd codal-microbit-nrf5sdk && \
-    git switch clang-revised && \
     
     cd /home/microbit-v2-samples-llvm/libraries/codal-microbit-v2 && \
     

--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ docker run --name llvm microbit-llvm:latest
 docker start llvm
 docker cp llvm:/home/microbit-v2-samples-llvm/build/MICROBIT.hex .
 ```
+To extract the newlib artefact (This will need optimising before sending to browser):
+```
+docker cp llvm:/home/archive.tar .
+```

--- a/README.md
+++ b/README.md
@@ -16,3 +16,11 @@ To jump into a container:
 ```
 docker run -it --rm microbit-llvm
 ```
+
+Steps to extract the hex (Users passing their own main does not work as of now, but this is a good foundation):
+```
+docker build -t "microbit-llvm" .
+docker run --name llvm microbit-llvm:latest
+docker start llvm
+docker cp llvm:/home/microbit-v2-samples-llvm/build/MICROBIT.hex .
+```


### PR DESCRIPTION
The LLVM build is still heavily depended on the GNU Arm Embedded Toolchain, and something to maybe consider moving away from. This Dockerfile approaches this problem by:
1. Creating a script to run arm-none-eabi-gcc, scraping information of where the newlib header files exist on the system.
2. Add these flags, along with some other modifcations to target-locked.json. This is best documented in the Dockerfile.
3. Run CMake & make, CMake is invoked directly to output compile_commands.json. This could be useful for the cpp-editor.
4. Upto this point the build will have failed, due to linker problems, this is expected.
5. Run arm-none-eabi-g++ with the -(v)erbose flag, on the Link stage letting arm-none-eabi-g++ parse the input.
6. Scrape this output and replace it with LLVMs linker (ld.lld). Run newly generated command.
7. Finally, turn the executable into a hex file.